### PR TITLE
feat(observability): add Sentry error tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,14 @@
 NEXT_PUBLIC_API_URL=https://rewardsapi.hireagent.co
 
 # ============================================
+# Error Tracking (Sentry)
+# ============================================
+# DSN from sentry.io project settings (jackson-mobile); leave empty to disable
+NEXT_PUBLIC_SENTRY_DSN=
+# uat | production; if unset, inferred from NEXT_PUBLIC_API_URL
+NEXT_PUBLIC_SENTRY_ENV=
+
+# ============================================
 # Verisoul Fraud Prevention
 # ============================================
 NEXT_PUBLIC_VERISOUL_API_KEY=your_verisoul_api_key_here

--- a/app/layout.js
+++ b/app/layout.js
@@ -5,6 +5,7 @@ import StatusBarSetter from "@/components/StatusBarSetter";
 import SplashScreen from "@/components/SplashScreen";
 import AdjustInitializer from "@/components/AdjustInitializer";
 import VPNDetectorProvider from "@/components/VPNDetectorProvider";
+import ErrorTrackingProvider from "@/components/ErrorTrackingProvider";
 
 export const metadata = {
   title: "Jackson Rewards",
@@ -108,11 +109,13 @@ export default function RootLayout({ children }) {
         <SplashScreen>
           <ReduxProvider>
             <AuthProvider>
-              <VPNDetectorProvider>
-                <AdjustInitializer />
-                <StatusBarSetter />
-                {children}
-              </VPNDetectorProvider>
+              <ErrorTrackingProvider>
+                <VPNDetectorProvider>
+                  <AdjustInitializer />
+                  <StatusBarSetter />
+                  {children}
+                </VPNDetectorProvider>
+              </ErrorTrackingProvider>
             </AuthProvider>
           </ReduxProvider>
         </SplashScreen>

--- a/components/ErrorTrackingProvider.js
+++ b/components/ErrorTrackingProvider.js
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect } from "react";
+import * as Sentry from "@sentry/react";
+import {
+  initErrorTracking,
+  syncErrorTrackingUser,
+} from "@/lib/errorTracking";
+import { useAuth } from "@/contexts/AuthContext";
+
+// Init at module load so errors during first render are already captured
+initErrorTracking();
+
+function CrashFallback({ resetError }) {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-black text-white px-8 text-center">
+      <p className="text-lg font-semibold mb-2">Something went wrong</p>
+      <p className="text-sm text-gray-400 mb-6">
+        The error has been reported. Please try again.
+      </p>
+      <button
+        onClick={() => {
+          if (resetError) resetError();
+          window.location.href = "/";
+        }}
+        className="px-6 py-3 rounded-full bg-white text-black text-sm font-semibold"
+      >
+        Reload app
+      </button>
+    </div>
+  );
+}
+
+/**
+ * Wraps the app in a Sentry ErrorBoundary (a render crash previously meant a
+ * silent white screen) and keeps the tracked user in sync with auth state.
+ * Must be mounted inside AuthProvider.
+ */
+export default function ErrorTrackingProvider({ children }) {
+  const { user } = useAuth();
+
+  useEffect(() => {
+    syncErrorTrackingUser(user);
+  }, [user]);
+
+  return (
+    <Sentry.ErrorBoundary
+      fallback={({ resetError }) => <CrashFallback resetError={resetError} />}
+    >
+      {children}
+    </Sentry.ErrorBoundary>
+  );
+}

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,5 +1,6 @@
 import { getUserFromLocalStorage } from "./utils";
 import { getIntegrityToken } from "./playIntegrity";
+import { reportApiFailure } from "./errorTracking";
 
 // A custom error class to hold structured API error data
 class ApiError extends Error {
@@ -381,6 +382,14 @@ const apiRequest = async (
       endpoint,
       error: error.message,
       type: error.name,
+    });
+
+    // Report to error tracking (5xx -> event, 4xx/network -> breadcrumb)
+    reportApiFailure({
+      endpoint,
+      method,
+      status: error instanceof ApiError ? error.status : 0,
+      message: error.message,
     });
 
     // Handle AbortError (timeout)

--- a/lib/errorTracking.js
+++ b/lib/errorTracking.js
@@ -1,0 +1,85 @@
+/**
+ * Error tracking via Sentry (sentry.io).
+ *
+ * - initErrorTracking(): call once on app start (client only). No-ops when
+ *   NEXT_PUBLIC_SENTRY_DSN is not set, so local dev is unaffected.
+ * - syncErrorTrackingUser(user): attach/detach the logged-in user so every
+ *   event shows who hit it.
+ * - reportApiFailure(...): called from lib/api.js — captures 5xx/server
+ *   failures as events, records 4xx/network issues as breadcrumbs only
+ *   (mobile networks flake constantly; those would drown the real signal).
+ */
+import * as Sentry from "@sentry/react";
+import { Capacitor } from "@capacitor/core";
+
+const DSN = process.env.NEXT_PUBLIC_SENTRY_DSN;
+
+// uat | production — explicit override wins, otherwise inferred from the API host
+const ENVIRONMENT =
+  process.env.NEXT_PUBLIC_SENTRY_ENV ||
+  ((process.env.NEXT_PUBLIC_API_URL || "").includes("uat")
+    ? "uat"
+    : "production");
+
+let initialized = false;
+
+export const initErrorTracking = () => {
+  if (initialized || typeof window === "undefined" || !DSN) return;
+  initialized = true;
+
+  Sentry.init({
+    dsn: DSN,
+    environment: ENVIRONMENT,
+    release: process.env.NEXT_PUBLIC_APP_VERSION || undefined,
+    // Errors only — keeps us within the Sentry free-tier event quota
+    tracesSampleRate: 0,
+    // Browser noise that isn't actionable
+    ignoreErrors: [
+      "ResizeObserver loop limit exceeded",
+      "ResizeObserver loop completed with undelivered notifications",
+    ],
+  });
+
+  Sentry.setTag("platform", Capacitor.getPlatform()); // ios | android | web
+
+  console.log(
+    `✅ Error tracking initialized (env: ${ENVIRONMENT}, platform: ${Capacitor.getPlatform()})`,
+  );
+};
+
+export const syncErrorTrackingUser = (user) => {
+  if (!initialized) return;
+  const id = user?._id || user?.id;
+  if (id) {
+    Sentry.setUser({ id: String(id) });
+  } else {
+    Sentry.setUser(null);
+  }
+};
+
+export const reportApiFailure = ({ endpoint, method, status, message }) => {
+  if (!initialized) return;
+
+  // Server-side failures are actionable — capture as events
+  if (status >= 500) {
+    Sentry.withScope((scope) => {
+      scope.setTag("api_endpoint", endpoint);
+      scope.setTag("http_status", String(status));
+      scope.setFingerprint(["api-failure", method, endpoint, String(status)]);
+      Sentry.captureMessage(
+        `API ${method} ${endpoint} failed with ${status}: ${message}`,
+        "error",
+      );
+    });
+    return;
+  }
+
+  // 4xx / timeouts / network errors: breadcrumb only, visible on later events
+  Sentry.addBreadcrumb({
+    category: "api",
+    level: "warning",
+    message: `${method} ${endpoint} -> ${status || "network-error"}: ${message}`,
+  });
+};
+
+export { Sentry };

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@heroicons/react": "^2.2.0",
         "@radix-ui/react-slot": "^1.2.3",
         "@reduxjs/toolkit": "^2.9.0",
+        "@sentry/react": "^10.69.0",
         "@tanstack/react-query": "^5.90.5",
         "@tanstack/react-query-devtools": "^5.90.2",
         "capacitor-native-biometric": "^4.2.2",
@@ -2513,6 +2514,112 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.12.0.tgz",
       "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==",
       "dev": true
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.69.0.tgz",
+      "integrity": "sha512-8391tnm96YbR7b8SYfEA/NEIZuyb2r3SZrtAT0bhZtjlujcYWjo7gugQvk8sWLU9cAa/euD00eJoIoJvNfpd7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.69.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.69.0",
+        "@sentry/feedback": "10.69.0",
+        "@sentry/replay": "10.69.0",
+        "@sentry/replay-canvas": "10.69.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser-utils": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.69.0.tgz",
+      "integrity": "sha512-e/u1Abj0zRPwR/deGZAP3GOULrsx67/XXnM5Skniqs4uxTsdNtPek1Nef0tpxwaQJYxwh6pWdhswLPPbbPOgBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.69.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.69.0.tgz",
+      "integrity": "sha512-+uuqVEeiDzYuAKjZLqsROKXvRTbl/QeH0gfGRtpYib1cud4rAFWRIkFmcR7Jb7JGFYwmReyQotiTj/hcDszTZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/feedback": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.69.0.tgz",
+      "integrity": "sha512-qrGz5Qaw93/IhMjlFN6uIaXeHwgHDaKGa6FkTAP6PonpkvSbGGqan6xfsENxzj9HUVoli1lZ6tMRDnt2qtSPhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.69.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.69.0.tgz",
+      "integrity": "sha512-f0Il/JMteHjdWPNZQB3rtp1Pcj2Leb3p0KSZuv3rh0EUril9CbWtQVy5zJhoAppi+MWWmgRWa+6BpHbQf+ABQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.69.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.69.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/replay": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.69.0.tgz",
+      "integrity": "sha512-uRhmNhtFGPOlM0iniVmWKAX3KVXI0le41yYK/iKdPjinT9jA3ZrmykO/Fv1v/KI5znOtwa9D6eHRnDTTMRxFrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.69.0",
+        "@sentry/core": "10.69.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/replay-canvas": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.69.0.tgz",
+      "integrity": "sha512-VF6nXvSninHcc7dC1Zme0RjkC7VgRMCixs6jKaQX5zTNeqTW3dZGSefSOVv+ZteRi3hJvVORq985VjUC9Z/0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.69.0",
+        "@sentry/replay": "10.69.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@heroicons/react": "^2.2.0",
     "@radix-ui/react-slot": "^1.2.3",
     "@reduxjs/toolkit": "^2.9.0",
+    "@sentry/react": "^10.69.0",
     "@tanstack/react-query": "^5.90.5",
     "@tanstack/react-query-devtools": "^5.90.2",
     "capacitor-native-biometric": "^4.2.2",


### PR DESCRIPTION
## Summary
- Adds `@sentry/react` error tracking (org: 365-aitech, project: jackson-mobile), disabled until `NEXT_PUBLIC_SENTRY_DSN` is set in the build env.
- `ErrorTrackingProvider` (wraps VPNDetectorProvider): render crashes are reported and show a recovery screen instead of a silent white screen; logged-in user attached to every event; `platform: android` tag via Capacitor.
- `lib/api.js` reports API failures: 5xx as alertable events, 4xx/network as breadcrumbs (so flaky mobile networks do not drown the signal).
- `environment` tag (uat/production) inferred from `NEXT_PUBLIC_API_URL`.

## Note
`npm install` in this repo requires `--legacy-peer-deps` (pre-existing @capacitor-community/advertising-id@8 vs @capacitor/core@7 conflict).

## Testing
- `next build` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)